### PR TITLE
Fixing the facebook-sdk dependency for 1.0.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,10 +18,10 @@ setup(
         'django',
         'django-annoying',
         'django-social-api>=0.1.1',
-        'facebook-sdk==1.0.0a0',
+        'facebook-sdk==1.0.0',
         'python-dateutil>=1.5',
     ],
-    dependency_links=['https://github.com/pythonforfacebook/facebook-sdk/tarball/master#egg=facebook-sdk-1.0.0a0'],
+    dependency_links=['https://github.com/pythonforfacebook/facebook-sdk/tarball/master#egg=facebook-sdk-1.0.0'],
     classifiers=[
         'Development Status :: 4 - Beta',
         'Environment :: Web Environment',


### PR DESCRIPTION
Previously, installation failed because facebook-sdk 1.0.0a0 couldn't be found. This fix looks for 1.0.0 instead.
